### PR TITLE
Add a proxy service, hitting the service on localhost:80 will route to the portal service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,8 @@ services:
 
   portal:
     build: .      
-    ports:
-      - "3000:3000"
+    # ports:
+    #   - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
       NEXT_PUBLIC_HASURA_URL: ${NEXT_PUBLIC_HASURA_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,3 +106,13 @@ services:
 # volumes:
 #   db_data:
 #   fa_config:
+
+  proxy:
+    image: nginx:latest
+    container_name: nginx-proxy
+    restart: unless-stopped
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./proxy-default.conf:/etc/nginx/conf.d/default.conf

--- a/proxy-default.conf
+++ b/proxy-default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://portal:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_connect_timeout 5;
+        proxy_send_timeout 60;
+        proxy_read_timeout 70;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+    }
+
+}

--- a/proxy-default.conf
+++ b/proxy-default.conf
@@ -2,7 +2,7 @@ server {
     listen 80;
     server_name localhost;
 
-    location / {
+    location /admin {
         proxy_pass http://portal:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION

## Description

Add a new service in docker-compose file and proxy-default.conf. 

## How to test
Run docker-compose up and hit `localhost:80` it should return the portal service