### PR TITLE
Add reverse proxy for /admin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,3 +106,13 @@ services:
 # volumes:
 #   db_data:
 #   fa_config:
+
+  # proxy:
+  #   image: nginx:latest
+  #   container_name: nginx-proxy
+  #   restart: unless-stopped
+  #   ports:
+  #     - 80:80
+  #     - 443:443
+  #   volumes:
+  #     - ./proxy-default.conf:/etc/nginx/conf.d/default.conf

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,11 @@
 /** @type {import('next').NextConfig} */
+
+const isProd = process.env.NODE_ENV === 'production'
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  assetPrefix: isProd ? '/admin' : undefined,
 }
 
 module.exports = nextConfig

--- a/proxy-default.conf
+++ b/proxy-default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location /admin/ {
+        proxy_pass http://portal:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_connect_timeout 5;
+        proxy_send_timeout 60;
+        proxy_read_timeout 70;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+    }
+
+}


### PR DESCRIPTION
## Description

Reverse proxy setup to deploy admin app on /admin endpoint from 3000 port.

### Changes

Added a proxy service in compose, which I have commented out to not hinder local development

PS: Added a base prefix of `/admin` for a production run to serve static files from `/admin`